### PR TITLE
(#16) pandoc for compiling the paper.pdf in local machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ share/**
 lib64/**
 __pycache__/**
 .pytest_cache/**
+paper/paper.pdf
 

--- a/paper/Makefile
+++ b/paper/Makefile
@@ -1,0 +1,2 @@
+all: paper.md paper.bib
+	pandoc -o paper.pdf paper.md --citeproc


### PR DESCRIPTION
This PR adds a Makefile to build paper.md and paper.bib to generate paper.pdf.

Runs on Linux and MacOS.

usage:

`# make all`

output:

paper.pdf


to clean:

`make clean`
